### PR TITLE
fixes for Xcode 7.3.1

### DIFF
--- a/KSTabView.podspec
+++ b/KSTabView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'KSTabView'
-  s.version = '0.3.0'
+  s.version = '0.3.1'
   s.license = 'MIT'
   s.summary = 'Simple and Lightweight TabView for Mac'
   s.homepage = 'https://github.com/kaunteya/KSTabView'

--- a/KSTabView.swift
+++ b/KSTabView.swift
@@ -248,7 +248,7 @@ extension KSTabView {
             self.identifier = aButton.identifier
             self.button = aButton
             self.target = tabView
-            self.action = "buttonPressed:"
+            self.action = #selector(buttonPressed)
             self.addSubview(self.button)
             self.button.frame.origin = NSMakePoint(parentTabView.buttonPadding, selectionLineHeight * 1.5)
 


### PR DESCRIPTION
Hello!

The KSTabView Cocoapod does not work out of the box under Xcode 7.3.1 as the Podspec (with a version number of `0.3.0`) was pushed a year ago while you merged some useful changes 9-10 months ago.  

So in this pull request, I've bumped the minor version number of the pod spec (you still need to push it via `pod trunk push KSTabView.podspec` after you validate it) and I also fixed a deprecated warning.

Once I move to Xcode 8 & Swift 3, I might open another PR for that as well.

I hope this helps!
